### PR TITLE
Breaking change: configuration is now loaded from config files instead from the 'event'.

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -1,0 +1,18 @@
+module.exports = {
+  "filters": [
+    {
+      "Name": "tag:Name",
+      "Values": [
+        "automated-backup"
+      ]
+    },
+    // {
+    //   "Name": "description",
+    //   "Values": [
+    //     "Created by *"
+    //   ]
+    // }
+  ],
+  "dryRun": true,
+  "rotate": 7
+};

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "main": "index.js",
   "dependencies": {
     "async": "~1.5.0",
-    "underscore": "~1.8.3",
-    "aws-sdk": "^2.2.13"
+    "aws-sdk": "^2.2.13",
+    "config": "^1.17.1",
+    "underscore": "~1.8.3"
   },
   "devDependencies": {
     "mocha": "^2.3.3",
@@ -30,13 +31,27 @@
   "homepage": "https://github.com/szkkentaro/rotate-snapshot",
   "eslintConfig": {
     "rules": {
-        "no-console": 0,
-        "indent": [ 2, 2 ],
-        "quotes": [ 2, "double" ],
-        "linebreak-style": [ 2, "unix" ],
-        "semi": [ 2, "always" ]
+      "no-console": 0,
+      "indent": [
+        2,
+        2
+      ],
+      "quotes": [
+        2,
+        "double"
+      ],
+      "linebreak-style": [
+        2,
+        "unix"
+      ],
+      "semi": [
+        2,
+        "always"
+      ]
     },
-    "env": { "node": true },
+    "env": {
+      "node": true
+    },
     "extends": "eslint:recommended"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "scripts": {
     "lint": "eslint *.js",
-    "test": "npm -s run-script lint && mocha --reporter spec test/"
+    "test": "npm -s run-script lint && mocha --reporter spec test/",
+    "package-for-deploy" : "rm -rf node_modules/ && npm install async config underscore && zip -v -r -9 rotate.snapshot.zip  *"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
A very common use case for deleting old snapshots would be emulating a "cron job" that runs
at a regular interval.

Lambda supports this model with a "Scheduled Event", but this event cannot pass
through configuration. Instead, configuration is loaded through a config file through
the very flexible "node-config" module.

I think this design is better than passing the configuration through the event because
it seems the configuration of the lambda function together with the code in one place.

Since passing configuration by "event" is no longer support, a major version
bump is required, and the documentation may need to be updated a bit further as
well.